### PR TITLE
Fixes body class typo, removes border

### DIFF
--- a/src/microsoft-trydotnet-editor/src/index.css
+++ b/src/microsoft-trydotnet-editor/src/index.css
@@ -1,7 +1,6 @@
-.body {
+body {
 	width: auto;
 	height: auto;
-	border: 1px solid #ccc;
 	margin: 0;
 }
 


### PR DESCRIPTION
Removes unnecessary border, reverts CSS rule back to targeting the `body` element instead of a non-existent CSS Class.